### PR TITLE
機能追加(座標に応じた肉切り&効果音再生重複防止)

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -9,7 +9,10 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 	int image = LoadGraph("./img/Knife_a.png");
 	int imgBack = LoadGraph("./img/Main.png");
-	int imgmiddle = LoadGraph("./img/meet_main.png");
+	int imgmiddle[4];
+
+	//画像を分割してロード
+	LoadDivGraph("./img/meet_main.png", 3, 3, 1, 268, 412, imgmiddle);
 
 	char StrBuf[128], StrBuf2[32];
 	int MouseX, MouseY;
@@ -44,7 +47,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		GetMousePoint(&MouseX, &MouseY);
 
 		DrawRotaGraph(300, 250, 0.5, 0.0, imgBack, TRUE);
-		DrawRotaGraph(300, 200, 0.5, 0.0, imgmiddle, TRUE);
+
+		DrawRotaGraph(180, 200, 0.46, 0.0, imgmiddle[0], TRUE);
+		DrawRotaGraph(304, 200, 0.46, 0.0, imgmiddle[1], TRUE);
+		DrawRotaGraph(428, 200, 0.46, 0.0, imgmiddle[2], TRUE);
+
 		DrawRotaGraph(x, y, 0.5, 0.0, image, TRUE);
 
 
@@ -71,11 +78,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		else {
 			PlaySoundMem(Handle, DX_PLAYTYPE_BACK, FALSE); // 効果音を再生する
 		}
-
-		
-
-
-	
 
 	}
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -9,7 +9,14 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 	int image = LoadGraph("./img/Knife_a.png");
 	int imgBack = LoadGraph("./img/Main.png");
+	int Handle = LoadSoundMem("./snd/Start.mp3");
+	int Handle1 = LoadSoundMem("./snd/Center.mp3");
 	int imgmiddle[4];
+	int counter = 0;
+
+	int steakX[4] = { 180, 304, 428 };
+	int steakY[4] = { 200, 200, 200 };
+
 
 	//画像を分割してロード
 	LoadDivGraph("./img/meet_main.png", 3, 3, 1, 268, 412, imgmiddle);
@@ -22,12 +29,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	{
 		return -1;    // エラーが起きたら直ちに終了
 	}
-
-	//int Mouse = GetMouseInput();
-	int Handle = LoadSoundMem("./snd/Start.mp3");
-	int Handle1 = LoadSoundMem("./snd/Center.mp3");
-
-
 
 	SetMouseDispFlag(TRUE);
 	StringCr = GetColor(255, 255, 255);
@@ -48,14 +49,16 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 		DrawRotaGraph(300, 250, 0.5, 0.0, imgBack, TRUE);
 
-		DrawRotaGraph(180, 200, 0.46, 0.0, imgmiddle[0], TRUE);
-		DrawRotaGraph(304, 200, 0.46, 0.0, imgmiddle[1], TRUE);
-		DrawRotaGraph(428, 200, 0.46, 0.0, imgmiddle[2], TRUE);
+		DrawRotaGraph(steakX[0], steakY[0], 0.46, 0.0, imgmiddle[0], TRUE);
+		DrawRotaGraph(steakX[1], steakY[1], 0.46, 0.0, imgmiddle[1], TRUE);
+		DrawRotaGraph(steakX[2], steakY[2], 0.46, 0.0, imgmiddle[2], TRUE);
 
 		DrawRotaGraph(x, y, 0.5, 0.0, image, TRUE);
 
 
 		ScreenFlip();//裏画面を表画面に反映
+
+
 
 		lstrcpy(StrBuf, "座標X"); // 文字列"座標 Ｘ"をStrBufにコピー	
 		_itoa(MouseX, StrBuf2, 10); // MouseXの値を文字列にしてStrBuf2に格納
@@ -77,6 +80,26 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		}
 		else {
 			PlaySoundMem(Handle, DX_PLAYTYPE_BACK, FALSE); // 効果音を再生する
+		}
+
+		if ((MouseX > 129) && (MouseX < 516)) {
+			if ((MouseY > 150) && (MouseY < 200)) {
+				counter++;
+				if (counter == 30) {
+					steakX[0]--;
+					counter = 0;
+				}
+			}
+		}
+
+		if ((MouseY > 150) && (MouseY < 220)) {
+			if ((MouseX > 129) && (MouseX < 496)) {
+				counter++;
+				if (counter == 30) {
+					steakX[0]--;
+					counter = 0;
+				}
+			}
 		}
 
 	}

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,8 +1,15 @@
-# define _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
 #include "DxLib.h"
 
-
+//グローバル変数の定義
+int counter = 0;
+int steakX[4] = { 180, 304, 428 };
+int steakY[4] = { 200, 200, 200 };
+int MouseX, MouseY;
 char Key[256];
+
+void AreaCheckA();
+void AreaCheckB();
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
 	if (ChangeWindowMode(TRUE) != DX_CHANGESCREEN_OK || DxLib_Init() == -1) return -1; //初期化処理
@@ -12,17 +19,11 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	int Handle = LoadSoundMem("./snd/Start.mp3");
 	int Handle1 = LoadSoundMem("./snd/Center.mp3");
 	int imgmiddle[4];
-	int counter = 0;
-
-	int steakX[4] = { 180, 304, 428 };
-	int steakY[4] = { 200, 200, 200 };
-
 
 	//画像を分割してロード
 	LoadDivGraph("./img/meet_main.png", 3, 3, 1, 268, 412, imgmiddle);
 
 	char StrBuf[128], StrBuf2[32];
-	int MouseX, MouseY;
 	int StringCr, BoxCr;
 
 	if (DxLib_Init() == -1)    // ＤＸライブラリ初期化処理
@@ -35,8 +36,8 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 	BoxCr = GetColor(0, 0, 0);
 
-	ChangeVolumeSoundMem(255 * 30/100, Handle);
-	ChangeVolumeSoundMem(255 * 50/ 100, Handle1);
+	ChangeVolumeSoundMem(255 * 30 / 100, Handle);
+	ChangeVolumeSoundMem(255 * 50 / 100, Handle1);
 
 
 	while (!ProcessMessage() && !ClearDrawScreen() && !GetHitKeyStateAll(Key) && !Key[KEY_INPUT_ESCAPE]) {
@@ -75,32 +76,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		DrawFormatString(0, 60, 0xffffff, "%d", Handle);
 
 
-		if ((Mouse & MOUSE_INPUT_LEFT)!=0){
+		if ((Mouse & MOUSE_INPUT_LEFT) != 0) {
 			PlaySoundMem(Handle1, DX_PLAYTYPE_BACK, FALSE); // 効果音を再生する
 		}
 		else {
 			PlaySoundMem(Handle, DX_PLAYTYPE_BACK, FALSE); // 効果音を再生する
 		}
 
-		if ((MouseX > 129) && (MouseX < 516)) {
-			if ((MouseY > 150) && (MouseY < 200)) {
-				counter++;
-				if (counter == 30) {
-					steakX[0]--;
-					counter = 0;
-				}
-			}
-		}
-
-		if ((MouseY > 150) && (MouseY < 220)) {
-			if ((MouseX > 129) && (MouseX < 496)) {
-				counter++;
-				if (counter == 30) {
-					steakX[0]--;
-					counter = 0;
-				}
-			}
-		}
+		AreaCheckA();	//左の肉を動かすかチェック
+		AreaCheckB();	//右の肉を動かすかチェック
 
 	}
 
@@ -108,3 +92,46 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	return 0;
 }
 
+void AreaCheckA() {
+	if ((MouseX > 200) && (MouseX < 270)) {
+		if ((MouseY > 180) && (MouseY < 200)) {
+			counter++;
+			if (counter == 30) {
+				steakX[0]--;
+				counter = 0;
+			}
+		}
+	}
+
+	if ((MouseY > 180) && (MouseY < 220)) {
+		if ((MouseX > 200) && (MouseX < 270)) {
+			counter++;
+			if (counter == 30) {
+				steakX[0]--;
+				counter = 0;
+			}
+		}
+	}
+}
+
+void AreaCheckB() {
+	if ((MouseX > 350) && (MouseX < 516)) {
+		if ((MouseY > 150) && (MouseY < 200)) {
+			counter++;
+			if (counter == 30) {
+				steakX[2]++;
+				counter = 0;
+			}
+		}
+	}
+
+	if ((MouseY > 150) && (MouseY < 220)) {
+		if ((MouseX > 350) && (MouseX < 496)) {
+			counter++;
+			if (counter == 30) {
+				steakX[2]++;
+				counter = 0;
+			}
+		}
+	}
+}

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -6,19 +6,27 @@ int counter = 0;
 int steakX[4] = { 180, 304, 428 };
 int steakY[4] = { 200, 200, 200 };
 int MouseX, MouseY;
+int Handle1;
+int AudioCounter = 0;
+bool AudioPlay = false;
 char Key[256];
 
 void AreaCheckA();
 void AreaCheckB();
+void AudioCheck();
+void CutAudioStart();
 
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow) {
 	if (ChangeWindowMode(TRUE) != DX_CHANGESCREEN_OK || DxLib_Init() == -1) return -1; //初期化処理
 
+	int SoundCounter = 0;
 	int image = LoadGraph("./img/Knife_a.png");
 	int imgBack = LoadGraph("./img/Main.png");
 	int Handle = LoadSoundMem("./snd/Start.mp3");
-	int Handle1 = LoadSoundMem("./snd/Center.mp3");
 	int imgmiddle[4];
+
+	//音量大きめの焼く音を代入
+	Handle1 = LoadSoundMem("./snd/Center.mp3");
 
 	//画像を分割してロード
 	LoadDivGraph("./img/meet_main.png", 3, 3, 1, 268, 412, imgmiddle);
@@ -48,18 +56,15 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		GetMousePoint(&x, &y);
 		GetMousePoint(&MouseX, &MouseY);
 
+		//各種画像の読み込み
 		DrawRotaGraph(300, 250, 0.5, 0.0, imgBack, TRUE);
-
 		DrawRotaGraph(steakX[0], steakY[0], 0.46, 0.0, imgmiddle[0], TRUE);
 		DrawRotaGraph(steakX[1], steakY[1], 0.46, 0.0, imgmiddle[1], TRUE);
 		DrawRotaGraph(steakX[2], steakY[2], 0.46, 0.0, imgmiddle[2], TRUE);
-
 		DrawRotaGraph(x, y, 0.5, 0.0, image, TRUE);
 
 
 		ScreenFlip();//裏画面を表画面に反映
-
-
 
 		lstrcpy(StrBuf, "座標X"); // 文字列"座標 Ｘ"をStrBufにコピー	
 		_itoa(MouseX, StrBuf2, 10); // MouseXの値を文字列にしてStrBuf2に格納
@@ -70,19 +75,19 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 		DrawBox(0, 0, 200, 32, BoxCr, TRUE);
 
+		//デバッグ用(メモリにロードできているか確認)
 		DrawString(0, 0, StrBuf, StringCr);
 		DrawFormatString(0, 20, 0xffffff, "%d", image);
 		DrawFormatString(0, 40, 0xffffff, "%d", imgBack);
 		DrawFormatString(0, 60, 0xffffff, "%d", Handle);
+		DrawFormatString(0, 80, 0xffffff, "%d", Handle1);
 
-
-		if ((Mouse & MOUSE_INPUT_LEFT) != 0) {
-			PlaySoundMem(Handle1, DX_PLAYTYPE_BACK, FALSE); // 効果音を再生する
-		}
-		else {
+		//10秒の音源のため10秒に1回再生
+		if (SoundCounter % 600 == 0) {
 			PlaySoundMem(Handle, DX_PLAYTYPE_BACK, FALSE); // 効果音を再生する
 		}
 
+		AudioCheck();	//マウス動作後の効果音再生状態チェック
 		AreaCheckA();	//左の肉を動かすかチェック
 		AreaCheckB();	//右の肉を動かすかチェック
 
@@ -99,6 +104,7 @@ void AreaCheckA() {
 			if (counter == 30) {
 				steakX[0]--;
 				counter = 0;
+				CutAudioStart();
 			}
 		}
 	}
@@ -109,6 +115,7 @@ void AreaCheckA() {
 			if (counter == 30) {
 				steakX[0]--;
 				counter = 0;
+				CutAudioStart();
 			}
 		}
 	}
@@ -121,6 +128,7 @@ void AreaCheckB() {
 			if (counter == 30) {
 				steakX[2]++;
 				counter = 0;
+				CutAudioStart();
 			}
 		}
 	}
@@ -131,7 +139,25 @@ void AreaCheckB() {
 			if (counter == 30) {
 				steakX[2]++;
 				counter = 0;
+				CutAudioStart();
 			}
 		}
+	}
+}
+
+void AudioCheck() {
+	if (AudioPlay == true) {
+		AudioCounter++;
+		if (AudioCounter % 600 == 0) {
+			AudioPlay = false;
+			AudioCounter = 0;
+		}
+	}
+}
+
+void CutAudioStart() {
+	if (AudioPlay == false) {
+		PlaySoundMem(Handle1, DX_PLAYTYPE_BACK, FALSE);
+		AudioPlay = true;
 	}
 }


### PR DESCRIPTION
座標に応じてマウスを動かすと肉が切れるようにしました。  
また、肉が切れると同時に効果音の再生、効果音再生中は再再生しないよう防止する機能を追加しました。  
座標の関して判定位置の調整、関数化を行っています。  
<br />
確認後、問題なければ「Merge pull request」を押してブランチに適用させて下さい。